### PR TITLE
Enable using '%' to jump to matching tags

### DIFF
--- a/after/ftplugin/javascript.vim
+++ b/after/ftplugin/javascript.vim
@@ -1,0 +1,15 @@
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" Vim ftplugin file
+"
+" Language: JSX (JavaScript)
+" Maintainer: Max Wang <mxawng@gmail.com>
+" Depends: pangloss/vim-javascript
+"
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+" modified from html.vim
+if exists("loaded_matchit")
+  let b:match_ignorecase = 0
+  let b:match_words = '(:),\[:\],{:},<:>,' .
+        \ '<\@<=\([^/][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
+endif


### PR DESCRIPTION
This adds a file which enables matchit to be used with JSX tags, using a regex taken from `/usr/local/share/vim/vim74/ftplugin/html.vim` (on my machine).

This means when pressing `%` on the opening or closing part of a JSX tag the cursor will jump to the matching tag. It requires that the user has matchit (which comes with Vim) enabled by putting

```
runtime macros/matchit.vim
```

in their `.vimrc`.
