### PR TITLE
Call the search function with the wrapping flag on

### DIFF
--- a/after/jsx-pragma.vim
+++ b/after/jsx-pragma.vim
@@ -23,4 +23,4 @@ if !g:jsx_pragma_required | finish | endif
 " Look for the @jsx pragma.  It must be included in a docblock comment before
 " anything else in the file (except whitespace).
 let s:jsx_pragma_pattern = '\%^\_s*\/\*\*\%(\_.\%(\*\/\)\@!\)*@jsx\_.\{-}\*\/'
-let b:jsx_pragma_found = search(s:jsx_pragma_pattern, 'np')
+let b:jsx_pragma_found = search(s:jsx_pragma_pattern, 'npw')


### PR DESCRIPTION
There's a (very improbable) user configuration that could make the detection fail without this flag:

```
autocmd BufReadPost * exe "normal! '\""
set nowrapscan
```
