### PR TITLE
Escape filename when sourcing config file

### DIFF
--- a/after/indent/javascript.vim
+++ b/after/indent/javascript.vim
@@ -8,7 +8,7 @@
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 " Do nothing if we don't find the @jsx pragma (and we care).
-exec 'source '.expand('<sfile>:p:h:h').'/jsx-config.vim'
+exec 'source '.fnameescape(expand('<sfile>:p:h:h').'/jsx-config.vim')
 if g:jsx_pragma_required && !b:jsx_pragma_found | finish | endif
 
 " Do nothing if we don't have the .jsx extension (and we care).

--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -10,7 +10,7 @@
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 " Do nothing if we don't find the @jsx pragma (and we care).
-exec 'source '.expand('<sfile>:p:h:h').'/jsx-config.vim'
+exec 'source '.fnameescape(expand('<sfile>:p:h:h').'/jsx-config.vim')
 if g:jsx_pragma_required && !b:jsx_pragma_found | finish | endif
 
 " Do nothing if we don't have the .jsx extension (and we care).


### PR DESCRIPTION
If the filename is not escaped the sourcing will fail when the plugin is installed in a path containing spaces.