### PR TITLE
Add `setlocal suffixesadd+=.jsx` to ftplugin

### DIFF
--- a/after/ftplugin/jsx.vim
+++ b/after/ftplugin/jsx.vim
@@ -13,3 +13,5 @@ if exists("loaded_matchit")
   let b:match_words = '(:),\[:\],{:},<:>,' .
         \ '<\@<=\([^/][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
 endif
+
+setlocal suffixesadd+=.jsx


### PR DESCRIPTION
This suffixesadd setting helps Vim understand text that references a
path and does not contain the .jsx extension, as is often the case in
CommonJS style require statements. This improves motions like `gf` and
commands like `:find`. More information:

  http://usevim.com/2013/01/04/vim101-jumping/