### PR TITLE
Escape file path in javascript.vim

### DIFF
--- a/after/ftdetect/javascript.vim
+++ b/after/ftdetect/javascript.vim
@@ -6,7 +6,7 @@
 "
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-exec 'source '.expand('<sfile>:p:h:h').'/jsx-config.vim'
+exec 'source '.fnameescape(expand('<sfile>:p:h:h').'/jsx-config.vim')
 
 fu! <SID>EnableJSX()
   if g:jsx_pragma_required && !b:jsx_pragma_found | return 0 | endif


### PR DESCRIPTION
Apologies, had to remove the previous pull request so that I could apply the same method of escaping that you use in jsx.vim in /indent and /syntax.