### PR TITLE
Add support for multiline opening tags

### DIFF
--- a/after/indent/jsx.vim
+++ b/after/indent/jsx.vim
@@ -25,8 +25,7 @@ setlocal indentkeys=0{,0},0),0],0\,,!^F,o,O,e
 setlocal indentkeys+=*<Return>,<>>,<<>,/
 
 " Self-closing tag regex.
-let s:sctag = '^\s*\/>\s*;\='
-let s:multilineopentag = '^\s*>\s*;\='
+let s:endtag = '^\s*\/\?>\s*;\='
 
 " Get all syntax types at the beginning of a given line.
 fu! SynSOL(lnum)
@@ -75,23 +74,13 @@ fu! GetJsxIndent()
   if (SynXMLish(prevsyn) || SynJSXBlockEnd(prevsyn)) && SynXMLishAny(cursyn)
     let ind = XmlIndentGet(v:lnum, 0)
 
-    " Align '/>' with '<' for multiline self-closing tags.
-    if getline(v:lnum) =~? s:sctag
+    " Align '/>' and '>' with '<' for multiline tags.
+    if getline(v:lnum) =~? s:endtag
       let ind = ind - &sw
     endif
 
-    " Then correct the indentation of any JSX following '/>'.
-    if getline(v:lnum - 1) =~? s:sctag
-      let ind = ind + &sw
-    endif
-    
-    " Align '>' with '<' for multiline opening tags.
-    if getline(v:lnum) =~? s:multilineopentag
-      let ind = ind - &sw
-    endif
-
-    " Then correct the indentation of any JSX following '>'.
-    if getline(v:lnum - 1) =~? s:multilineopentag
+    " Then correct the indentation of any JSX following '/>' or '>'.
+    if getline(v:lnum - 1) =~? s:endtag
       let ind = ind + &sw
     endif
   else

--- a/after/indent/jsx.vim
+++ b/after/indent/jsx.vim
@@ -26,6 +26,7 @@ setlocal indentkeys+=*<Return>,<>>,<<>,/
 
 " Self-closing tag regex.
 let s:sctag = '^\s*\/>\s*;\='
+let s:multilineopentag = '^\s*>\s*;\='
 
 " Get all syntax types at the beginning of a given line.
 fu! SynSOL(lnum)
@@ -82,6 +83,18 @@ fu! GetJsxIndent()
     " Then correct the indentation of any JSX following '/>'.
     if getline(v:lnum - 1) =~? s:sctag
       let ind = ind + &sw
+    endif
+    
+    if g:jsx_multiline_opening_tags
+      " Align '>' with '<' for multiline opening tags.
+      if getline(v:lnum) =~? s:multilineopentag
+        let ind = ind - &sw
+      endif
+
+      " Then correct the indentation of any JSX following '>'.
+      if getline(v:lnum - 1) =~? s:multilineopentag
+        let ind = ind + &sw
+      endif
     endif
   else
     let ind = GetJavascriptIndent()

--- a/after/indent/jsx.vim
+++ b/after/indent/jsx.vim
@@ -24,7 +24,7 @@ setlocal indentkeys=0{,0},0),0],0\,,!^F,o,O,e
 " XML indentkeys
 setlocal indentkeys+=*<Return>,<>>,<<>,/
 
-" Self-closing tag regex.
+" Multiline end tag regex (line beginning with '>' or '/>')
 let s:endtag = '^\s*\/\?>\s*;\='
 
 " Get all syntax types at the beginning of a given line.

--- a/after/indent/jsx.vim
+++ b/after/indent/jsx.vim
@@ -85,16 +85,14 @@ fu! GetJsxIndent()
       let ind = ind + &sw
     endif
     
-    if g:jsx_multiline_opening_tags
-      " Align '>' with '<' for multiline opening tags.
-      if getline(v:lnum) =~? s:multilineopentag
-        let ind = ind - &sw
-      endif
+    " Align '>' with '<' for multiline opening tags.
+    if getline(v:lnum) =~? s:multilineopentag
+      let ind = ind - &sw
+    endif
 
-      " Then correct the indentation of any JSX following '>'.
-      if getline(v:lnum - 1) =~? s:multilineopentag
-        let ind = ind + &sw
-      endif
+    " Then correct the indentation of any JSX following '>'.
+    if getline(v:lnum - 1) =~? s:multilineopentag
+      let ind = ind + &sw
     endif
   else
     let ind = GetJavascriptIndent()


### PR DESCRIPTION
Fixes #74.

This (optionally) corrects the indentation when opening tags to span multiple lines. So instead of:

```xml
<Foo
  prop1="hey"
  prop2="there"
  >
  <Child />
</Foo>
```

The indentation will now be:

```xml
<Foo
  prop1="hey"
  prop2="there"
>
  <Child />
</Foo>
```

I imitated the way it's done for multiline self-closing tags. I put it behind a flag, but it may be the case that this should be the default.

Regardless of whether or not a user of this plugin prefers to keep the closing angle-bracket on the same line as the last prop or not, this change makes the use case of keeping it on a separate line behave as expected instead of being indented at the same level as the child components.