### PR TITLE
update README to provide correct filenames for manual installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ directly into their respective destinations.  If you have existing after syntax
 or indent files for Javascript, you'll probably want to do something like
 
     mkdir -p ~/.vim/after/syntax/javascript
-    cp path/to/vim-jsx/after/syntax/javascript.vim ~/.vim/after/syntax/javascript/javascript.vim
+    cp path/to/vim-jsx/after/syntax/jsx.vim ~/.vim/after/syntax/javascript/jsx.vim
     mkdir -p ~/.vim/after/indent/javascript
-    cp path/to/vim-jsx/after/indent/javascript.vim ~/.vim/after/indent/javascript/javascript.vim
+    cp path/to/vim-jsx/after/indent/jsx.vim ~/.vim/after/indent/javascript/jsx.vim
 
 
 [1]: http://facebook.github.io/react/           "React"


### PR DESCRIPTION
This is really minor, and I'm not sure who does manual installation anyways, but I figured this might as well be correct. It looks like the files are named `jsx.vim`, not `javascript.vim` in the repo.