### PR TITLE
Enable spell checking on jsxRegion

### DIFF
--- a/after/syntax/jsx.vim
+++ b/after/syntax/jsx.vim
@@ -46,7 +46,7 @@ syn region jsxChild contained start=+{+ end=++ contains=jsBlock,javascriptBlock
 " preceding it, to avoid conflicts with, respectively, the left shift operator
 " and generic Flow type annotations (http://flowtype.org/).
 syn region jsxRegion
-  \ contains=@XMLSyntax,jsxRegion,jsxChild,jsBlock,javascriptBlock
+  \ contains=@Spell,@XMLSyntax,jsxRegion,jsxChild,jsBlock,javascriptBlock
   \ start=+\%(<\|\w\)\@<!<\z([a-zA-Z][a-zA-Z0-9:\-.]*\)+
   \ skip=+<!--\_.\{-}-->+
   \ end=+</\z1\_\s\{-}>+


### PR DESCRIPTION
It would be nice to be able to spell-check text inside JSX elements. This seems like the right way to enable that.