### PR TITLE
Fix to syntax close tag is disabled

### DIFF
--- a/after/syntax/jsx.vim
+++ b/after/syntax/jsx.vim
@@ -50,7 +50,7 @@ syn region jsxRegion
   \ start=+\%(<\|\w\)\@<!<\z([a-zA-Z][a-zA-Z0-9:\-.]*\)+
   \ skip=+<!--\_.\{-}-->+
   \ end=+</\z1\_\s\{-}>+
-  \ end=+/>+
+  \ end=+/?>+
   \ keepend
   \ extend
 


### PR DESCRIPTION
before:

![2016-07-04 0 47 38](https://cloud.githubusercontent.com/assets/9594376/16546289/f07dcf04-4180-11e6-9a44-e864d36d6239.png)

after:

![2016-07-04 0 48 56](https://cloud.githubusercontent.com/assets/9594376/16546300/20c5e034-4181-11e6-89d9-f8520536b435.png)
