### PR TITLE
Add note for tmux users

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ comment.
 (Please feel free to disregard all this for feature requests and more
 corner-case bugs.)
 
+Note for `tmux` users: Just running `:source ~/.vimrc` after installation will
+not cause syntax highlighting to appear. Nor will closing your terminal, then
+reattaching to your current `tmux` session. You will have to kill your `tmux`
+session and attach to a new one to see the change take place.
+
 Usage
 -----
 


### PR DESCRIPTION
This PR adds a line of docs in the troubleshooting section for `tmux` users (a set up I imagine would be common). I installed this plugin according to the docs but wasn't able to get it to work, even when quitting iTerm and then reattaching to tmux. (I was tempted to file an issue or do more Googling, so I'm hoping to save someone the trouble in the future.) This PR clarifies that it's required to quit tmux entirely in order to see syntax highlighting after installation.

Even if this should be common knowledge, it's good to see a reminder.