### PR TITLE
Fall back to default indentation

### DIFF
--- a/after/indent/jsx.vim
+++ b/after/indent/jsx.vim
@@ -87,7 +87,7 @@ fu! GetJsxIndent()
       " For pangloss/vim-javascript.
       let ind = GetJavascriptIndent()
     else
-      let ind = indent(v:lnum)
+      let ind = cindent(v:lnum)
     endif
   endif
 


### PR DESCRIPTION
the `indent()` just returns the number of whitespace columns at the start of the line, and that on the current line is redundant and doesn't do anything. the default js indent file just turns on cindent so the `cindent()` function is the equivalent.