### PR TITLE
Improved b:match_words to work-around % jump issue

### DIFF
--- a/after/ftplugin/jsx.vim
+++ b/after/ftplugin/jsx.vim
@@ -10,7 +10,7 @@
 if exists("loaded_matchit")
   let b:match_ignorecase = 0
   let b:match_words = '(:),\[:\],{:},<:>,' .
-        \ '<\@<=\([^/][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
+        \ '<\@<=\([^/][^ \t>]*\)[^>]*\%(/\@<!>\|$\):<\@<=/\1>'
 endif
 
 setlocal suffixesadd+=.jsx


### PR DESCRIPTION
Improved b:match_words to work-around an issue that when a tag is
nested with same-name-self-closing tag, the % jump is broken. Here is a
more detailed example:

```
<Route path="/foo" component={Foo}>
  <Route path="/bar" component={Bar} /> # these two lines will match
</Route>                                # these two lines will match
```