### PR TITLE
Prevent clobbering of previous b:match_words

### DIFF
--- a/after/ftplugin/jsx.vim
+++ b/after/ftplugin/jsx.vim
@@ -9,8 +9,11 @@
 " modified from html.vim
 if exists("loaded_matchit")
   let b:match_ignorecase = 0
-  let b:match_words = '(:),\[:\],{:},<:>,' .
+  let s:jsx_match_words = '(:),\[:\],{:},<:>,' .
         \ '<\@<=\([^/][^ \t>]*\)[^>]*\%(/\@<!>\|$\):<\@<=/\1>'
+  let b:match_words = exists('b:match_words')
+    \ ? b:match_words . ',' . s:jsx_match_words
+    \ : s:jsx_match_words
 endif
 
 setlocal suffixesadd+=.jsx


### PR DESCRIPTION
Since b:match_words is defined in an after directory, it's likely to be
sourced after any user configuration, even those appearing in
\~/.vim/after (\~/.vim usually comes before plugin-specific paths in
runtimepath).

Any previously existing b:match_words should only be appended to instead
of outright clobbered, to preserve user configuration.