### PR TITLE
Don't let ':' terminate JSX classname

### DIFF
--- a/after/syntax/jsx.vim
+++ b/after/syntax/jsx.vim
@@ -47,7 +47,7 @@ syn region jsxChild contained start=+{+ end=++ contains=jsBlock,javascriptBlock
 " and generic Flow type annotations (http://flowtype.org/).
 syn region jsxRegion
   \ contains=@Spell,@XMLSyntax,jsxRegion,jsxChild,jsBlock,javascriptBlock
-  \ start=+\%(<\|\w\)\@<!<\z([a-zA-Z][a-zA-Z0-9:\-.]*\)+
+  \ start=+\%(<\|\w\)\@<!<\z([a-zA-Z][a-zA-Z0-9:\-.]*\>:\@!\)+
   \ skip=+<!--\_.\{-}-->+
   \ end=+</\z1\_\s\{-}>+
   \ end=+/>+

--- a/after/syntax/jsx.vim
+++ b/after/syntax/jsx.vim
@@ -47,7 +47,7 @@ syn region jsxChild contained start=+{+ end=++ contains=jsBlock,javascriptBlock
 " and generic Flow type annotations (http://flowtype.org/).
 syn region jsxRegion
   \ contains=@Spell,@XMLSyntax,jsxRegion,jsxChild,jsBlock,javascriptBlock
-  \ start=+\%(<\|\w\)\@<!<\z([a-zA-Z][a-zA-Z0-9:\-.]*\>:\@!\)+
+  \ start=+\%(<\|\w\)\@<!<\z([a-zA-Z][a-zA-Z0-9:\-.]*\>[:,]\@!\)\([^>]*>(\)\@!+
   \ skip=+<!--\_.\{-}-->+
   \ end=+</\z1\_\s\{-}>+
   \ end=+/>+


### PR DESCRIPTION
Flow uses syntax like `<T: Object>` to say "generic in type T, provided
that it's an object."

JSX technically allows ':' in a "JSXNamespacedName" (see [here][1]).
However, this is rarely ever used, and even still, a ':' can't be used
to terminate a namespaced name. This commit explicitly checks for the
':' at the end.

Without this change, vim-jsx tries to treat `<T: Object>` as the opening
tag of a JSX block, meaning that everything after it gets highlighted
as if it were inside an XML tag.

[1]: https://facebook.github.io/jsx/