### PR TITLE
Defer setup of global flags until needed

### DIFF
--- a/ftdetect/javascript.vim
+++ b/ftdetect/javascript.vim
@@ -6,20 +6,20 @@
 "
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-" Whether the .jsx extension is required.
-if !exists('g:jsx_ext_required')
-  let g:jsx_ext_required = 1
-endif
-
-" Whether the @jsx pragma is required.
-if !exists('g:jsx_pragma_required')
-  let g:jsx_pragma_required = 0
-endif
-
 let s:jsx_pragma_pattern = '\%^\_s*\/\*\*\%(\_.\%(\*\/\)\@!\)*@jsx\_.\{-}\*\/'
 
 " Whether to set the JSX filetype on *.js files.
 fu! <SID>EnableJSX()
+  " Whether the .jsx extension is required.
+  if !exists('g:jsx_ext_required')
+    let g:jsx_ext_required = 1
+  endif
+
+  " Whether the @jsx pragma is required.
+  if !exists('g:jsx_pragma_required')
+    let g:jsx_pragma_required = 0
+  endif
+
   if g:jsx_pragma_required && !exists('b:jsx_ext_found')
     " Look for the @jsx pragma.  It must be included in a docblock comment
     " before anything else in the file (except whitespace).


### PR DESCRIPTION
Many (most?) setups of vim won't even have these variables defined, _even if the user has defined them_ — because ftdetect runs so early.

Even if they were defined, there's no need to run these lines since they aren't being used unless `*.js` is triggered, so it's better to defer defining them.