### PR TITLE
Allow for .js by default #158

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ minimal comment.
 Usage
 -----
 
-By default, JSX syntax highlighting and indenting will be enabled only for
-files with the `.jsx` extension.  If you would like JSX in `.js` files, add
+By default, JSX syntax highlighting and indenting will be enabled for
+files with the `.js` and `.jsx` extension.  If you would like JSX only in `.jsx` files, add
 
 ```viml
-let g:jsx_ext_required = 0
+let g:jsx_ext_required = 1
 ```
 
 to your .vimrc or somewhere in your include path.  If you wish to restrict JSX

--- a/ftdetect/javascript.vim
+++ b/ftdetect/javascript.vim
@@ -8,7 +8,7 @@
 
 " Whether the .jsx extension is required.
 if !exists('g:jsx_ext_required')
-  let g:jsx_ext_required = 1
+  let g:jsx_ext_required = 0
 endif
 
 " Whether the @jsx pragma is required.


### PR DESCRIPTION
Discussion in #158 

`g:jsx_ext_required = 0` is set by default.