### PR TITLE
fix curly brace matching

### DIFF
--- a/after/syntax/jsx.vim
+++ b/after/syntax/jsx.vim
@@ -30,13 +30,13 @@ endif
 "   - othree/yajs.vim:              javascriptNoReserved
 
 
-" JSX attributes should color as JS.  Note the trivial end pattern; we let
-" jsBlock take care of ending the region.
-syn region xmlString contained start=+{+ end=++ contains=jsBlock,javascriptBlock
+" JSX attributes should color as JS.
+syn region xmlString contained start=+{+ end=+}+ contains=jsBlock,javascriptBlock
 
 " JSX child blocks behave just like JSX attributes, except that (a) they are
 " syntactically distinct, and (b) they need the syn-extend argument, or else
-" nested XML end-tag patterns may end the outer jsxRegion.
+" nested XML end-tag patterns may end the outer jsxRegion.  Note the trivial
+" end pattern; we let jsBlock take care of ending the region.
 syn region jsxChild contained start=+{+ end=++ contains=jsBlock,javascriptBlock
   \ extend
 


### PR DESCRIPTION
fixes #146 

Without this change there were three issues:
1. Incorrect curly braces were highlighting
2. In `neovim`, pressing `%` would move to the highlighted, incorrect brace
3. The colors between curly braces as a jsx attribute were highlighted the same color as an attribute, rather than, and the first curly brace was the same color as an xml string. Now everything between the braces is the same color as an xml string