### PR TITLE
fixed the issue with the matchit plugin

### DIFF
--- a/after/ftplugin/jsx.vim
+++ b/after/ftplugin/jsx.vim
@@ -6,14 +6,15 @@
 "
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
+
 " modified from html.vim
-if exists("loaded_matchit")
+if exists("loaded_matchit") && !exists('b:jsx_match_words')
   let b:match_ignorecase = 0
-  let s:jsx_match_words = '(:),\[:\],{:},<:>,' .
+  let b:jsx_match_words = '(:),\[:\],{:},<:>,' .
         \ '<\@<=\([^/][^ \t>]*\)[^>]*\%(/\@<!>\|$\):<\@<=/\1>'
   let b:match_words = exists('b:match_words')
-    \ ? b:match_words . ',' . s:jsx_match_words
-    \ : s:jsx_match_words
+    \ ? b:match_words . ',' . b:jsx_match_words
+    \ : b:jsx_match_words
 endif
 
 setlocal suffixesadd+=.jsx


### PR DESCRIPTION
I don't really know how it happens, but in some cases the filetype is set multiple times and the code that sets `b:match_words` executes for each instance. This leads to the `b:match_words` being duplicated, when the number of duplicates reaches 10, there is a regex error that there are beyond 10 references and '%' breaks. You can see how I fixed this in the PR