### PR TITLE
Set javacsript.jsx filetype for ES6 files if EnableJSX

### DIFF
--- a/ftdetect/javascript.vim
+++ b/ftdetect/javascript.vim
@@ -34,3 +34,5 @@ autocmd BufNewFile,BufRead *.jsx let b:jsx_ext_found = 1
 autocmd BufNewFile,BufRead *.jsx set filetype=javascript.jsx
 autocmd BufNewFile,BufRead *.js
   \ if <SID>EnableJSX() | set filetype=javascript.jsx | endif
+autocmd BufNewFile,BufRead *.es6
+  \ if <SID>EnableJSX() | set filetype=javascript.jsx | endif


### PR DESCRIPTION
I've been sitting on this change for 2.5 years apparently, and one of my coworkers ran into the same issue in one of our codebases (syntax highlighting JSX in an ES6 file), so I figured I'd try and get this merged upstream.

I'm not sure if piggy backing on the EnableJSX check is appropriate here, or if there should be a separate check for enabling es6. 

Or if this change is wildly off-base or too specific to my own use case, feel free to close.