### PR TITLE
Don't modify b:match_words on reloading file

### DIFF
--- a/after/ftplugin/jsx.vim
+++ b/after/ftplugin/jsx.vim
@@ -11,9 +11,18 @@ if exists("loaded_matchit")
   let b:match_ignorecase = 0
   let s:jsx_match_words = '(:),\[:\],{:},<:>,' .
         \ '<\@<=\([^/][^ \t>]*\)[^>]*\%(/\@<!>\|$\):<\@<=/\1>'
-  let b:match_words = exists('b:match_words')
-    \ ? b:match_words . ',' . s:jsx_match_words
-    \ : s:jsx_match_words
+
+  if !exists('b:loaded_jsx_match_words')
+    let b:loaded_jsx_match_words = 0
+  endif
+
+  if b:loaded_jsx_match_words == 0
+    let b:match_words = exists('b:match_words')
+      \ ? b:match_words . ',' . s:jsx_match_words
+      \ : s:jsx_match_words
+  endif
+
+  let b:loaded_jsx_match_words = 1
 endif
 
 setlocal suffixesadd+=.jsx


### PR DESCRIPTION
When using `:edit` to reload jsx file, the b:match_words variable is appended with the jsx match words again. After multiple reloads, vim will complain `E51: Too many '('` when using `%` to jump to matching parenthese.